### PR TITLE
Set XML header to utf-8

### DIFF
--- a/lib/jekyll-utf8.rb
+++ b/lib/jekyll-utf8.rb
@@ -9,6 +9,7 @@ module Jekyll
       def self.webrick_options(config)
         options = _original_webrick_options(config)
         options[:MimeTypes].merge!({'html' => 'text/html; charset=utf-8'})
+        options[:MimeTypes].merge!({'xml'  => 'text/xml; charset=utf-8'})
         options
       end
 


### PR DESCRIPTION
This PR sets the correct header for RSS feeds with UTF8 characters.

```
$ curl http://localhost:4000/feed.xml -I
HTTP/1.1 200 OK
Etag: 64af8c-2356-552805aa
Content-Type: text/xml; charset=utf-8
Content-Length: 9046
Last-Modified: Fri, 10 Apr 2015 17:17:30 GMT
Server: WEBrick/1.3.1 (Ruby/2.2.1/2015-02-26)
Date: Fri, 10 Apr 2015 17:17:34 GMT
Connection: Keep-Alive
```

You can see it live in action schneems.com via https://github.com/schneems/schneems/commit/4c70a5d77db132f914432790515cad3cff2b061b
